### PR TITLE
Support py3 and unihandecode 0.81

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class locale_sdist(sdist):
         return sdist.run(self)
 
 
-devtools_req = ['click', 'remember', 'logbook', 'unihandecode>=0.50']
+devtools_req = ['click', 'repoze.lru', 'six', 'logbook', 'unihandecode>=0.81']
 setup(name='slugger',
       version='0.2.3.dev1',
       description=('Slugging done right. Tries to support close to 300 '
@@ -30,7 +30,7 @@ setup(name='slugger',
       author_email='git@marcbrinkmann.de',
       url='http://github.com/mbr/slugger',
       license='LGPLv2.1',
-      install_requires=['remember', 'unihandecode>=0.50'],
+      install_requires=['repoze.lru', 'six', 'unihandecode>=0.81'],
       package_data={
           'slugger': ['localedata/*'],
       },
@@ -46,7 +46,7 @@ setup(name='slugger',
       },
       classifiers=[
           'Programming Language :: Python :: 2',
-          #'Programming Language :: Python :: 3',  # no python 3 support yet
+          'Programming Language :: Python :: 3',
       ],
       cmdclass={'sdist': locale_sdist},
       zip_safe=False,

--- a/slugger/__init__.py
+++ b/slugger/__init__.py
@@ -9,14 +9,10 @@ from remember.memoize import memoize
 import pkg_resources
 import unihandecode
 
-from exc import LanguageNotFoundError
-import languages
-import languages.default_language
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+from .exc import LanguageNotFoundError
+import slugger.languages
+import slugger.languages.default_language
+from six.moves import cPickle
 
 
 _MEMOIZE = 20
@@ -96,7 +92,7 @@ def _load_ttbl(lang):
             if c.endswith('.bz2'):
                 buf = bz2.decompress(buf)
 
-            return pickle.loads(buf)
+            return cPickle.loads(buf)
 
     raise LanguageNotFoundError('Could not find translation table for %s' %
                                 lang)

--- a/slugger/__init__.py
+++ b/slugger/__init__.py
@@ -1,11 +1,11 @@
-__version__ = '0.2.2.dev1'
+__version__ = '0.2.3.dev1'
 
 import bz2
 import imp
 import re
 import sys
 
-from remember.memoize import memoize
+from repoze.lru import lru_cache
 import pkg_resources
 import unihandecode
 
@@ -19,7 +19,7 @@ _MEMOIZE = 20
 _LANGCODE_RE = re.compile('^([a-z]+)(?:_([A-Z]+).*)?$')
 
 
-@memoize(_MEMOIZE)
+@lru_cache(maxsize=_MEMOIZE)
 def _split_language(lang_code):
     m = _LANGCODE_RE.match(lang_code)
 
@@ -30,7 +30,7 @@ def _split_language(lang_code):
     return m.groups()
 
 
-@memoize(_MEMOIZE)
+@lru_cache(maxsize=_MEMOIZE)
 def _load_language(lang):
     language, territory = _split_language(lang)
 
@@ -67,7 +67,7 @@ def _load_language(lang):
     return mod
 
 
-@memoize(_MEMOIZE)
+@lru_cache(maxsize=_MEMOIZE)
 def _load_ttbl(lang):
     language, territory = _split_language(lang)
 
@@ -98,7 +98,7 @@ def _load_ttbl(lang):
                                 lang)
 
 
-@memoize(_MEMOIZE)
+@lru_cache(maxsize=_MEMOIZE)
 def _compile_rpl_exp(tbl):
     assert(tbl), "cannot compile empty table"
 

--- a/slugger/glibcparse/cli.py
+++ b/slugger/glibcparse/cli.py
@@ -13,7 +13,7 @@ from six.moves import cPickle
 import click
 import logbook
 import logbook.more
-from remember.memoize import memoize
+from repoze.lru import lru_cache
 
 from .tokenize import Tokenizer
 from .preprocess import Screener
@@ -27,7 +27,7 @@ def parse_translit(fn):
     return _parse_translit(os.path.normpath(os.path.abspath(fn)))
 
 
-@memoize(100)
+@lru_cache(maxsize=100)
 def _parse_translit(fn):
     with open(fn) as f:
         log.info("parse %s" % os.path.relpath(fn))

--- a/slugger/glibcparse/cli.py
+++ b/slugger/glibcparse/cli.py
@@ -9,11 +9,7 @@ help.
 import bz2
 import os
 import sys
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
+from six.moves import cPickle
 import click
 import logbook
 import logbook.more
@@ -46,7 +42,7 @@ def _parse_translit(fn):
 
         try:
             p.parse()
-        except LException, e:
+        except LException as e:
             log.critical("%s:%d.%d %s" % (
                 fn,
                 e.src.lineno,
@@ -111,6 +107,6 @@ def _main(loglevel, preprocess_only, output_dir, files, compress):
                     outfile = open(out_fn, 'w') if not compress else\
                         bz2.BZ2File(out_fn, 'w', 1024**2, 9)
                     try:
-                        pickle.dump(ttbl, outfile, pickle.HIGHEST_PROTOCOL)
+                        cPickle.dump(ttbl, outfile, cPickle.HIGHEST_PROTOCOL)
                     finally:
                         outfile.close()

--- a/slugger/glibcparse/parser.py
+++ b/slugger/glibcparse/parser.py
@@ -1,5 +1,5 @@
 from logbook import Logger
-
+import six
 from .exc import ParserError
 
 
@@ -13,7 +13,7 @@ class BaseParser(object):
         return self.tokenizer.colno
 
     def _expect(self, *args):
-        t = self.tokens.next()
+        t = six.next(self.tokens)
         if not args == t[:len(args)]:
             raise ParserError(self, 'Expected %s, got %s instead' %
                               (args, t))
@@ -34,7 +34,7 @@ class BlockParser(BaseParser):
         def _yield_until_end_of(blocktype):
             prev = None
             while True:
-                t = self.tokens.next()
+                t = six.next(self.tokens)
                 if ('KEYWORD', 'END') == t and ('EOL',) == prev:
                     self._expect('KEYWORD', blocktype)
                     self._expect('EOL')
@@ -81,7 +81,7 @@ class TranslitParser(BlockParser):
                 if inside_translit:
                     raise ParserError(self, 'copy inside translit section')
 
-                t_fn = token_iter.next()
+                t_fn = six.next(token_iter)
                 if not (t_fn[0], 'STRING'):
                     raise ParserError(self, 'expected filename to copy')
 
@@ -89,7 +89,7 @@ class TranslitParser(BlockParser):
                 self.log.info('copying file "%s"' % fn)
                 self.ttbl.update(self.parse_func(fn))
 
-                if not ('EOL',) == token_iter.next():
+                if not ('EOL',) == six.next(token_iter):
                     raise ParserError(self, 'garbage after copy')
                 continue
 
@@ -97,7 +97,7 @@ class TranslitParser(BlockParser):
                 if not inside_translit:
                     raise ParserError(self, 'include outside translit section')
 
-                t_fn = token_iter.next()
+                t_fn = six.next(token_iter)
                 if not (t_fn[0], 'STRING'):
                     raise ParserError(self, 'expected filename to copy')
 
@@ -105,7 +105,7 @@ class TranslitParser(BlockParser):
                 self.log.info('including file "%s"' % fn)
                 self.ttbl.update(self.parse_func(fn))
 
-                while token_iter.next() != ('EOL',):
+                while six.next(token_iter) != ('EOL',):
                     pass
                 continue
 
@@ -121,7 +121,7 @@ class TranslitParser(BlockParser):
 
             if ('KEYWORD', 'default_missing') == t:
                 self.log.debug('skipping default_missing')
-                while token_iter.next() != ('EOL',):
+                while six.next(token_iter) != ('EOL',):
                     pass
                 continue
 
@@ -134,7 +134,7 @@ class TranslitParser(BlockParser):
                     if ('SEMICOLON',) == t:
                         groups.append(current_group)
                         current_group = []
-                        t = token_iter.next()
+                        t = six.next(token_iter)
                         continue
 
                     if not 'STRING' == t[0]:
@@ -142,7 +142,7 @@ class TranslitParser(BlockParser):
                                                 'instead' % (t,))
                     current_group.append(t[1])
 
-                    t = token_iter.next()
+                    t = six.next(token_iter)
 
                 if current_group:
                     groups.append(current_group)

--- a/slugger/glibcparse/preprocess.py
+++ b/slugger/glibcparse/preprocess.py
@@ -1,4 +1,5 @@
 import re
+import six
 
 PREFACE_RE = re.compile(
     '^(\s*(?:escape_char|comment_char)\s*.\s*\n)*'
@@ -11,7 +12,7 @@ def strip_comments(comment_char, escape_char, string_delim, i):
 
     # remove comments
     while True:
-        c = i.next()
+        c = six.next(i)
 
         if escaped:
             escaped = False
@@ -24,7 +25,7 @@ def strip_comments(comment_char, escape_char, string_delim, i):
             inside_string = not inside_string
         elif comment_char == c and not inside_string:
             while c != '\n':
-                c = i.next()
+                c = six.next(i)
 
         yield c
 
@@ -76,7 +77,7 @@ class Screener(object):
             else:
                 self.colno += 1
 
-            c = self.i.next()
+            c = six.next(self.i)
             if '\n' == c:
                 self._newline = True
             return c

--- a/slugger/glibcparse/preprocess.py
+++ b/slugger/glibcparse/preprocess.py
@@ -51,7 +51,8 @@ def preprocess(buf):
                 comment_char = ch
 
         # start reading after preface
-        i = iter(buffer(buf, preface_m.end()))
+        buf2 = buf[preface_m.end():]
+        i = iter(buf2)
     else:
         i = iter(buf)
 

--- a/slugger/glibcparse/tokenize.py
+++ b/slugger/glibcparse/tokenize.py
@@ -1,10 +1,6 @@
 import re
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
-
+import six
+from six.moves import StringIO
 from .exc import TokenizerError
 
 KEYWORDS = ('LC_IDENTIFICATION', 'LC_CTYPE', 'LC_COLLATE', 'LC_TIME',
@@ -19,7 +15,7 @@ _U_RE = re.compile('<U([0-9A-F]+)>')
 def _uni_sub(s):
     def _u_repl(m):
         code_point = int(m.group(1), 16)
-        return unichr(code_point)
+        return six.unichr(code_point)
 
     return _U_RE.sub(_u_repl, s)
 
@@ -51,7 +47,7 @@ class Tokenizer(object):
 
     def __iter__(self):
         def _getch():
-            c = i.next()
+            c = six.next(i)
             if self.escape_char == c:
                 # drop escape chars
                 return _getch()


### PR DESCRIPTION
Support (partially) python3 by

- Use six for compatibility functions. 
- Replace deprecated old buffer
- Use repose.lru instead of remember.memoize which is not maintained now.

and refer to new release unihandecode 0.81

Still not working `python setup.py sdist` on python3 because of file I/O encoding issue.
